### PR TITLE
Add iptables persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vagrant
+
+examples/roles/azavea.iptables-persistent

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -3,6 +3,17 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+# Ensure role dependencies are in place
+if [ "up", "provision" ].include?(ARGV.first) &&
+  !(File.directory?("roles/azavea.iptables-persistent") || File.symlink?("roles/azavea.iptables-persistent"))
+
+  unless system("ansible-galaxy install --force -r roles.txt -p roles")
+    $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
+    $stderr.puts "is available."
+    exit(1)
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,0 +1,1 @@
+azavea.iptables-persistent,0.1.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,5 @@ galaxy_info:
     - trusty
   categories:
   - system
-dependencies: []
+dependencies:
+  - { role: "azavea.iptables-persistent" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,3 +24,7 @@
 - name: Setup iptables NAT
   command: "iptables -t nat -A POSTROUTING -o {{ pptpd_interface }} -j MASQUERADE"
   when: not iptables_nat.stdout | search("MASQUERADE")
+
+- name: Persist iptables rules
+  command: "service iptables-persistent save"
+  when: not iptables_nat.stdout | search("MASQUERADE")


### PR DESCRIPTION
This changeset adds support for     `iptables` persistence via the `iptables-persistence` package. After the `iptables` rules are applied, they're saved via `service iptables-persistent save`, which handles bringing them back on reboot.
